### PR TITLE
chore: setup hunky, lint-staged and type check pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,5 @@
+# check if the project compilation
+npx tsc --noEmit
+
 # apply format and check for warnsing about unused variable and parameters
 npx lint-staged 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ts-template-v22",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {
         "@eslint/js": "^9.37.0",
@@ -26,6 +27,9 @@
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.46.0",
         "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=22.0.0 <23.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4570,9 +4574,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.1.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.9.tgz",
-      "integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
+      "version": "7.1.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.12.tgz",
+      "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
       "prettier --write"
     ],
     "*.{ts,tsx}": [
-      "vitest related --run",
-      "npx tsc --noEmit"
+      "vitest related --run"
     ]
   },
   "engines": {


### PR DESCRIPTION
## Summary
Setup of Git pre-commit hooks to ensure code quality before commits.

## Deatils
- Configured lint-staged to run checks only on staged files.
- Added TypeScript type checking (npx tsc --noEmit) to prevent commits with type errors.

## Motivation
Before this change, commits could be made even if the code had type or lint errors.
This setup improves developer experience and code reliability by catching issues early, right before they reach the repository.